### PR TITLE
play if-then-else precedence much safer

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -512,7 +512,8 @@ let rec pp_nix_expr_prec prec ppf nb =
         attributes
   | `NIf (cond,tbranch,ebranch) ->
       let paren = match prec with
-        | _ -> false
+        | `PElse -> false
+        | _ -> true
       in
       if paren then pp_print_text ppf "(" else ();
       fprintf ppf "@[if@ @[";


### PR DESCRIPTION
Nix is bad at parsing it, doesn't really expect it to be most places it
could be allowed.  It's probably more readable that way anyway.